### PR TITLE
feat: upgrade to Astro v6 beta + Cloudflare deploy config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,20 +3,10 @@ import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
 import AutoImport from "astro-auto-import";
-import { defineConfig } from "astro/config";
+import { defineConfig, sharpImageService } from "astro/config";
 import remarkCollapse from "remark-collapse";
 import remarkToc from "remark-toc";
-import sharp from "sharp";
 import config from "./src/config/config.json";
-
-let highlighter;
-async function getHighlighter() {
-  if (!highlighter) {
-    const { getHighlighter } = await import("shiki");
-    highlighter = await getHighlighter({ theme: "one-dark-pro" });
-  }
-  return highlighter;
-}
 
 // https://astro.build/config
 export default defineConfig({
@@ -24,7 +14,7 @@ export default defineConfig({
   base: config.site.base_path ? config.site.base_path : "/",
   trailingSlash: config.site.trailing_slash ? "always" : "never",
 
-  image: { service: sharp() },
+  image: { service: sharpImageService() },
   vite: { plugins: [tailwindcss()] },
 
   integrations: [
@@ -57,7 +47,5 @@ export default defineConfig({
       theme: "one-dark-pro",
       wrap: true,
     },
-    highlighter: getHighlighter,
-    extendDefaultPlugins: true,
   },
 });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "generate-json": "node scripts/jsonGenerator.js",
     "remove-darkmode": "node scripts/removeDarkmode.js && yarn format",
     "deploy:cf-workers": "npm run build && wrangler deploy",
-    "preview:cf-workers": "npm run build && wrangler dev"
+    "preview:cf-workers": "npm run build && wrangler dev",
+    "check": "astro check"
   },
   "dependencies": {
     "@astrojs/check": "0.9.7-beta.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geeky-astro",
-  "version": "6.0.0",
+  "version": "4.0.0",
   "description": "",
   "author": "statichunt",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geeky-astro",
-  "version": "3.1.0",
+  "version": "6.0.0",
   "description": "",
   "author": "statichunt",
   "license": "MIT",
@@ -11,15 +11,17 @@
     "build": "astro build",
     "format": "prettier -w ./src",
     "generate-json": "node scripts/jsonGenerator.js",
-    "remove-darkmode": "node scripts/removeDarkmode.js && yarn format"
+    "remove-darkmode": "node scripts/removeDarkmode.js && yarn format",
+    "deploy:cf-workers": "npm run build && wrangler deploy",
+    "preview:cf-workers": "npm run build && wrangler dev"
   },
   "dependencies": {
-    "@astrojs/check": "^0.9.4",
-    "@astrojs/mdx": "4.2.3",
-    "@astrojs/react": "4.2.3",
+    "@astrojs/check": "0.9.7-beta.1",
+    "@astrojs/mdx": "5.0.0-beta.9",
+    "@astrojs/react": "5.0.0-beta.3",
     "@astrojs/rss": "4.0.11",
-    "@astrojs/sitemap": "3.3.0",
-    "astro": "5.6.1",
+    "@astrojs/sitemap": "3.6.1-beta.3",
+    "astro": "6.0.0-beta.17",
     "astro-auto-import": "^0.4.4",
     "astro-font": "^1.0.0",
     "date-fns": "^4.1.0",
@@ -36,7 +38,7 @@
     "remark-collapse": "^0.1.2",
     "remark-toc": "^9.0.0",
     "swiper": "^11.2.6",
-    "vite": "^6.2.6"
+    "vite": "^7.3.1"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.10",
@@ -52,6 +54,7 @@
     "prettier-plugin-tailwindcss": "^0.6.11",
     "sharp": "0.33.5",
     "tailwindcss": "^4.1.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "wrangler": "^4"
   }
 }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
 import { glob } from "astro/loaders";
-import { defineCollection, z } from "astro:content";
+import { defineCollection } from "astro:content";
+import { z } from "astro/zod";
 
 const aboutCollection = defineCollection({
   loader: glob({ pattern: "**/*.{md,mdx}", base: "src/content/about" }),
@@ -84,7 +85,7 @@ const postsCollection = defineCollection({
     title: z.string().optional(),
     meta_title: z.string().optional(),
     description: z.string().optional(),
-    date: z.date().optional(),
+    date: z.coerce.date().optional(),
     image: z.string().optional(),
     categories: z.array(z.string()).optional(),
     featured: z.boolean().optional(),

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+  // Cloudflare Workers — Static Assets deployment
+  // Deploy:  npm run deploy:cf-workers
+  // Preview: npm run preview:cf-workers
+  "name": "geeky-astro",
+  "compatibility_date": "2026-03-01",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "404-page"
+  }
+}


### PR DESCRIPTION
Upgrades to Astro v6 beta (6.0.0-beta.17) + Cloudflare deploy config. Build: 0 errors. See branch feat/astro-v6-cloudflare.